### PR TITLE
adding javascript switch

### DIFF
--- a/tests/JavaScript.ipynb
+++ b/tests/JavaScript.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 43,
    "metadata": {
     "collapsed": false
    },
@@ -15,12 +15,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Allow loading with a dotted path"
+    "# Load into x"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 44,
    "metadata": {
     "collapsed": false
    },
@@ -54,7 +54,7 @@
       "application/javascript": [
        "(\n",
        "            window._yaml ? window._yaml : window._yaml = {}\n",
-       "        )[\"None\"] = 0.0;"
+       "        )[\"x\"] = [{\"name\": \"yamlmagic\"}, {\"description\": \"This is a multi-line string\\n\"}];"
       ],
       "text/plain": [
        "<IPython.core.display.Javascript object>"
@@ -62,105 +62,85 @@
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "0.0"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
-    "%%yaml --loader yaml.Loader\n",
-    "!!python/float 0"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "\n",
-       "            require(\n",
-       "                [\n",
-       "                    \"notebook/js/codecell\",\n",
-       "                    \"codemirror/mode/yaml/yaml\"\n",
-       "                ],\n",
-       "                function(cc){\n",
-       "                    cc.CodeCell.options_default.highlight_modes.magic_yaml = {\n",
-       "                        reg: [\"^%%yaml\"]\n",
-       "                    }\n",
-       "                }\n",
-       "            );\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/javascript": [
-       "(\n",
-       "            window._yaml ? window._yaml : window._yaml = {}\n",
-       "        )[\"None\"] = 0.0;"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "0.0"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "%%yaml -lyaml.Loader\n",
-    "!!python/float 0"
+    "%%yaml x -j\n",
+    "- name: yamlmagic\n",
+    "- description: |\n",
+    "    This is a multi-line string\n",
+    "# this is a comment, which won't end up in the data"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Allow loading an already-imported variable"
+    "# Execute something else"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 45,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "\n",
+       "            require(\n",
+       "                [\n",
+       "                    \"notebook/js/codecell\",\n",
+       "                    \"codemirror/mode/yaml/yaml\"\n",
+       "                ],\n",
+       "                function(cc){\n",
+       "                    cc.CodeCell.options_default.highlight_modes.magic_yaml = {\n",
+       "                        reg: [\"^%%yaml\"]\n",
+       "                    }\n",
+       "                }\n",
+       "            );\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/javascript": [
+       "console.log([{\"name\": \"yamlmagic\"}, {\"description\": \"This is a multi-line string\\n\"}])"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "from yaml import Loader as foo"
+    "%%yaml x --javascript-tmpl \"console.log({{{value}}})\"\n",
+    "- name: yamlmagic\n",
+    "- description: |\n",
+    "    This is a multi-line string\n",
+    "# this is a comment, which won't end up in the data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Update Metadata"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 46,
    "metadata": {
     "collapsed": false
    },
@@ -194,7 +174,7 @@
       "application/javascript": [
        "(\n",
        "            window._yaml ? window._yaml : window._yaml = {}\n",
-       "        )[\"None\"] = 0.0;"
+       "        )[\"x\"] = [{\"name\": \"yamlmagic\"}, {\"description\": \"This is a multi-line string\\n\"}];"
       ],
       "text/plain": [
        "<IPython.core.display.Javascript object>"
@@ -205,18 +185,112 @@
     },
     {
      "data": {
+      "application/javascript": [
+       "\n",
+       "        (window.Jupyter &&\n",
+       "            (window.Jupyter.notebook.metadata[\"x\"] = [{\"name\": \"yamlmagic\"}, {\"description\": \"This is a multi-line string\\n\"}])\n",
+       "        );\n",
+       "        "
+      ],
       "text/plain": [
-       "0.0"
+       "<IPython.core.display.Javascript object>"
       ]
      },
-     "execution_count": 5,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "%%yaml --loader foo\n",
-    "!!python/float 0"
+    "%%yaml x --meta\n",
+    "- name: yamlmagic\n",
+    "- description: |\n",
+    "    This is a multi-line string\n",
+    "# this is a comment, which won't end up in the data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Update Cell Metadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {
+    "collapsed": false,
+    "x": [
+     {
+      "name": "yamlmagic"
+     },
+     {
+      "description": "This is a multi-line string\n"
+     }
+    ]
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "\n",
+       "            require(\n",
+       "                [\n",
+       "                    \"notebook/js/codecell\",\n",
+       "                    \"codemirror/mode/yaml/yaml\"\n",
+       "                ],\n",
+       "                function(cc){\n",
+       "                    cc.CodeCell.options_default.highlight_modes.magic_yaml = {\n",
+       "                        reg: [\"^%%yaml\"]\n",
+       "                    }\n",
+       "                }\n",
+       "            );\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/javascript": [
+       "(\n",
+       "            window._yaml ? window._yaml : window._yaml = {}\n",
+       "        )[\"x\"] = [{\"name\": \"yamlmagic\"}, {\"description\": \"This is a multi-line string\\n\"}];"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/javascript": [
+       "\n",
+       "        this.wrapper && (this.wrapper.parent().data()\n",
+       "            .cell.metadata[\"x\"] = [{\"name\": \"yamlmagic\"}, {\"description\": \"This is a multi-line string\\n\"}]\n",
+       "        );\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%yaml x --cell-meta\n",
+    "- name: yamlmagic\n",
+    "- description: |\n",
+    "    This is a multi-line string\n",
+    "# this is a comment, which won't end up in the data"
    ]
   }
  ],
@@ -237,7 +311,15 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.5.0"
-  }
+  },
+  "x": [
+   {
+    "name": "yamlmagic"
+   },
+   {
+    "description": "This is a multi-line string\n"
+   }
+  ]
  },
  "nbformat": 4,
  "nbformat_minor": 0

--- a/tests/Simple.ipynb
+++ b/tests/Simple.ipynb
@@ -51,6 +51,20 @@
     },
     {
      "data": {
+      "application/javascript": [
+       "(\n",
+       "            window._yaml ? window._yaml : window._yaml = {}\n",
+       "        )[\"None\"] = [{\"name\": \"yamlmagic\"}, {\"description\": \"This is a multi-line string\\n\"}];"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
       "text/plain": [
        "[{'name': 'yamlmagic'}, {'description': 'This is a multi-line string\\n'}]"
       ]
@@ -117,6 +131,20 @@
        "                }\n",
        "            );\n",
        "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/javascript": [
+       "(\n",
+       "            window._yaml ? window._yaml : window._yaml = {}\n",
+       "        )[\"x\"] = [{\"name\": \"yamlmagic\"}, {\"description\": \"This is a multi-line string\\n\"}];"
       ],
       "text/plain": [
        "<IPython.core.display.Javascript object>"
@@ -227,7 +255,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.2"
+   "version": "3.5.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This allows being able to

``` yaml
%%yaml foo --javascript true
foo:
    - bar
```

and have `window._yaml.foo` set equal to `{foo: ["bar"]}`

Todo:
- [ ]: tests
- [ ]: clean up args (no `True`)

Questions?
- [ ]: more generalized templates for python/js generated script? Does this conflict with `loader`?
